### PR TITLE
Fix consolidation bugs and prompt improvements

### DIFF
--- a/consolidator.go
+++ b/consolidator.go
@@ -111,7 +111,7 @@ func (c *Consolidator) ConsolidateAgent(ctx context.Context, agentSlug, userID s
 func BuildAnalysisPrompt(memories []Memory, agentSlug string, metrics *RelationshipMetrics) string {
 	memoryText := ""
 	for _, mem := range memories {
-		timestamp := mem.CreatedAt.Format("15:04")
+		timestamp := mem.CreatedAt.Format("2006-01-02 15:04")
 		memoryText += fmt.Sprintf("[%s] %s (%s, importance: %.2f): %s\n",
 			timestamp, mem.MemoryType, mem.ID, mem.Importance, mem.Content)
 	}
@@ -189,6 +189,8 @@ func (c *Consolidator) applyConsolidation(ctx context.Context, result *Consolida
 			return fmt.Errorf("save consolidated memory: %w", err)
 		}
 
+		// Mark source memories as consolidated AFTER the replacement is saved
+		// to prevent data loss if the save fails.
 		if err := c.store.MarkMemoriesConsolidated(ctx, suggestion.MemoryIDs); err != nil {
 			return fmt.Errorf("mark consolidated: %w", err)
 		}

--- a/consolidator_test.go
+++ b/consolidator_test.go
@@ -39,10 +39,10 @@ func TestBuildAnalysisPrompt(t *testing.T) {
 	}
 
 	// Verify memories are formatted with timestamp, type, ID, importance, content
-	if !strings.Contains(prompt, "[14:30] episodic (mem-1, importance: 0.70): User asked about Go concurrency") {
+	if !strings.Contains(prompt, "[2026-03-07 14:30] episodic (mem-1, importance: 0.70): User asked about Go concurrency") {
 		t.Error("prompt should contain formatted first memory")
 	}
-	if !strings.Contains(prompt, "[15:00] emotional (mem-2, importance: 0.90): User expressed frustration with debugging") {
+	if !strings.Contains(prompt, "[2026-03-07 15:00] emotional (mem-2, importance: 0.90): User expressed frustration with debugging") {
 		t.Error("prompt should contain formatted second memory")
 	}
 

--- a/extractor.go
+++ b/extractor.go
@@ -123,7 +123,7 @@ func (e *Extractor) ExtractConversation(ctx context.Context, jobID, conversation
 func BuildExtractionPrompt(messages []ConversationMessage, agent *AgentInfo, metrics *RelationshipMetrics) string {
 	conversationText := ""
 	for _, msg := range messages {
-		timestamp := msg.CreatedAt.Format("15:04")
+		timestamp := msg.CreatedAt.Format("2006-01-02 15:04")
 		conversationText += fmt.Sprintf("[%s] %s: %s\n", timestamp, msg.Role, msg.Content)
 	}
 

--- a/server.go
+++ b/server.go
@@ -213,7 +213,7 @@ func (s *Server) handleConsolidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	axon.WriteJSON(w, http.StatusAccepted, map[string]string{
+	axon.WriteJSON(w, http.StatusOK, map[string]string{
 		"status": "completed",
 		"agent":  req.AgentSlug,
 		"user":   req.UserID,


### PR DESCRIPTION
## Summary
- **Misleading status code**: `handleConsolidate` returned 202 Accepted for a synchronous operation; now returns 200 OK
- **Date in prompts**: Extraction and consolidation prompts now include date alongside time for better temporal context
- Updated test expectations for new timestamp format

Closes #1

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes